### PR TITLE
tell snakemake to use scE2G frag_to_norm_bigWig for ATAC_norm

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -62,7 +62,7 @@ module encode_e2g:
 config = update_scE2G_config(config, encode_e2g_config, config["encode_re2g_dir"])
 
 ## Include Snakemake rules from ENCODE_rE2G
-use rule * from encode_e2g exclude generate_e2g_predictions, format_external_features_config, get_stats, generate_plots, all
+use rule * from encode_e2g exclude generate_e2g_predictions, format_external_features_config, get_stats, generate_plots, all, write_accessibility_bw_file
 
 # expand biosamples config
 BIOSAMPLE_DF = encode_e2g.ABC.enable_retry(
@@ -70,11 +70,6 @@ BIOSAMPLE_DF = encode_e2g.ABC.enable_retry(
 	func_args={'filepath_or_buffer': config["ABC_BIOSAMPLES"]}
 )
 BIOSAMPLE_DF = encode_e2g.expand_biosample_df(BIOSAMPLE_DF)
-
-## Resolve output ambiguity: scE2G bigWig rules and ENCODE_rE2G's write_accessibility_bw_file
-## both produce IGV_DIR/{biosample}/{id}.bw — prefer the scE2G rules
-ruleorder: frag_to_norm_bigWig > write_accessibility_bw_file
-ruleorder: frag_to_bigWig > write_accessibility_bw_file
 
 ## Include additional Snakemake rules
 include: os.path.join("rules", "frag_to_tagAlign.smk")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -71,6 +71,11 @@ BIOSAMPLE_DF = encode_e2g.ABC.enable_retry(
 )
 BIOSAMPLE_DF = encode_e2g.expand_biosample_df(BIOSAMPLE_DF)
 
+## Resolve output ambiguity: scE2G bigWig rules and ENCODE_rE2G's write_accessibility_bw_file
+## both produce IGV_DIR/{biosample}/{id}.bw — prefer the scE2G rules
+ruleorder: frag_to_norm_bigWig > write_accessibility_bw_file
+ruleorder: frag_to_bigWig > write_accessibility_bw_file
+
 ## Include additional Snakemake rules
 include: os.path.join("rules", "frag_to_tagAlign.smk")
 include: os.path.join("rules", "make_kendall_pairs.smk")


### PR DESCRIPTION
  ## Problem being addressed
 scE2G's frag_to_norm_bigWig rule (frag_to_tagAlign.smk:130) and the imported ENCODE_rE2G write_accessibility_bw_file rule (predictions.smk:103) both produce files matching the same pattern in IGV_DIR:                                                                   

## Solution
Remove import of ENCODE_rE2G write_accessibility_bw_file rule