### PR TITLE
Fix missing jq dependency breaking conda env creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git submodule update --init --recursive
       - run:
           name: Install basic OS pkgs
-          command: apt-get update && apt-get -y install curl vim
+          command: apt-get update && apt-get -y install curl vim jq
       # - run:
       #     name: Run Linter (python black)
       #     command: |

--- a/workflow/envs/sc_e2g.yml
+++ b/workflow/envs/sc_e2g.yml
@@ -10,6 +10,7 @@ dependencies:
   - ucsc-bedgraphtobigwig
   - click
   - csvtk
+  - jq
   - numpy
   - pandas
   - python>=3.6

--- a/workflow/envs/sc_e2g.yml
+++ b/workflow/envs/sc_e2g.yml
@@ -10,7 +10,6 @@ dependencies:
   - ucsc-bedgraphtobigwig
   - click
   - csvtk
-  - jq
   - numpy
   - pandas
   - python>=3.6


### PR DESCRIPTION
bioconductor-genomeinfodbdata's post-link script shells out to yq, which requires jq on PATH. It only worked before because jq happened to be present in the base image/host; CircleCI's condaforge/mambaforge image no longer has it, breaking mamba env create for encode_re2g and sc_e2g (both pull in bioconductor packages that depend on it).

- Pin ENCODE_rE2G submodule to dev @ 25fad30, which includes the jq fix
- Add jq to sc_e2g.yml, which has the same latent dependency
- Install jq via apt as a CircleCI-only safety net

Verified by running the full chr22 ENCODE-rE2G pipeline inside a condaforge/mambaforge container with no OS-level jq.

Also updates ENCODE-rE2G/workflow/scripts/feature_tables/gene_num_candidate_enh_gene.py to make better use of the cache by accessing data sequentially instead of functionally randomly