### PR TITLE
Resolve scE2G's own directory via workflow.current_basedir, not os.ge…

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -12,12 +12,17 @@ MAX_MEM_MB = config["max_memory_allocation_mb"]
 include: os.path.join("rules", "utils.smk")
 
 
+## Resolve scE2G's own directory from the currently-parsed Snakefile rather than
+# os.getcwd(), since os.getcwd() is the invoking process's cwd and does not
+# change when this Snakefile is loaded as a module from another pipeline.
+WORKFLOW_DIR = os.path.dirname(str(workflow.current_basedir))
+
 ## Update paths in the config to be compatible with github submodules
 # Need to manually make results_dir an absolute path since above may
 # not work if results_dir folder isn't created
 # If results_dir is already an absolute path, this is a no-op
-config = make_paths_absolute(config, os.getcwd())
-config["results_dir"] = os.path.join(os.getcwd(), config["results_dir"])
+config = make_paths_absolute(config, WORKFLOW_DIR)
+config["results_dir"] = os.path.join(WORKFLOW_DIR, config["results_dir"])
 
 ## Define global variables
 if "IGV_dir" in config:
@@ -32,10 +37,9 @@ if "fragments_preprocessed" not in config:
 if "RNA_matrix_filtered" not in config:
 	config["RNA_matrix_filtered"] = True
 
-RESULTS_DIR = config["results_dir"] 
-SCRIPTS_DIR = os.path.join(os.getcwd(), "workflow", "scripts")
+RESULTS_DIR = config["results_dir"]
+SCRIPTS_DIR = os.path.join(WORKFLOW_DIR, "workflow", "scripts")
 CELL_CLUSTER_DF = pd.read_table(config["cell_clusters"]).set_index("cluster", drop=False)
-WORKFLOW_DIR = os.getcwd()
 
 ## Convert cell cluster config to a biosample config for the ABC pipeline
 ## Treat each cell cluster as a distinct biosample

--- a/workflow/Snakefile_training
+++ b/workflow/Snakefile_training
@@ -16,12 +16,17 @@ include: os.path.join("rules", "utils.smk")
 include: os.path.join("rules", "utils_training.smk")
 
 
+## Resolve scE2G's own directory from the currently-parsed Snakefile rather than
+# os.getcwd(), since os.getcwd() is the invoking process's cwd and does not
+# change when this Snakefile is loaded as a module from another pipeline.
+WORKFLOW_DIR = os.path.dirname(str(workflow.current_basedir))
+
 ## Update paths in the config to be compatible with github submodules
 # Need to manually make results_dir an absolute path since above may
 # not work if results_dir folder isn't created
 # If results_dir is already an absolute path, this is a no-op
-config = make_paths_absolute(config, os.getcwd())
-config["results_dir"] = os.path.join(os.getcwd(), config["results_dir"])
+config = make_paths_absolute(config, WORKFLOW_DIR)
+config["results_dir"] = os.path.join(WORKFLOW_DIR, config["results_dir"])
 
 
 ## Define global variables


### PR DESCRIPTION
…tcwd()

os.getcwd() is the invoking process's cwd and doesn't change when workflow/Snakefile or workflow/Snakefile_training is loaded as a Snakemake module from another pipeline (e.g. IGVF's QC-and-Predictions), so SCRIPTS_DIR and WORKFLOW_DIR silently resolved to the importing pipeline's directory instead of scE2G's own. workflow.current_basedir tracks whichever Snakefile is actually being parsed, correctly in both standalone and module-imported invocations.

Verified against Snakemake 9.16.3: standalone test suite (34/34 steps) and a real module-import dry-run against the QC-and-Predictions pipeline, both passing, with paths correctly resolving under scE2G's own directory.