### PR TITLE
Fix/jq not on path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run: git submodule update --init --recursive
       - run:
           name: Install basic OS pkgs
-          command: apt-get update && apt-get -y install curl vim
+          command: apt-get update && apt-get -y install curl vim jq
       # - run:
       #     name: Run Linter (python black)
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,11 @@ jobs:
           command: |
             mamba env create -f workflow/envs/run_snakemake.yml
       - run:
+          name: Build rule conda envs (sc_e2g, encode_re2g, abcenv)
+          no_output_timeout: 30m
+          command: |
+            conda run -n run_snakemake snakemake -j1 --use-conda --conda-create-envs-only --configfile tests/config/test_config.yml
+      - run:
           name: Run tests
           no_output_timeout: 45m
           command: |


### PR DESCRIPTION
1. Add jq to CircleCI env to resolve CircleCI failures
2. Remove redundant sc-e2g env build
3. Separate the building of and usage of environments in Snakemake workflow into 2 distinct CircleCI tests for easier debugging: The first check will build abc-env, encode_re2g env, and sc-e2g env.  
4. Re-pin ENCODE-rE2G to improve runtime of ENCODE-rE2G/workflow/scripts/feature_tables/gen_num_candidate_enh_gene.py (prevent thrashing)